### PR TITLE
prov/efa: Emulated Atomic Support for Cuda Devices

### DIFF
--- a/include/ofi_hmem.h
+++ b/include/ofi_hmem.h
@@ -171,6 +171,7 @@ int cuda_gdrcopy_hmem_cleanup(void);
 int cuda_gdrcopy_dev_register(struct fi_mr_attr *mr_attr, uint64_t *handle);
 int cuda_gdrcopy_dev_unregister(uint64_t handle);
 int cuda_set_sync_memops(void *ptr);
+int cuda_flush_rdma_operations(void);
 
 #define ZE_MAX_DEVICES 8
 int ze_hmem_copy(uint64_t device, void *dst, const void *src, size_t size);

--- a/include/ofi_hmem.h
+++ b/include/ofi_hmem.h
@@ -290,6 +290,18 @@ ssize_t ofi_copy_to_hmem_iov(enum fi_hmem_iface hmem_iface, uint64_t device,
 			     size_t hmem_iov_count, uint64_t hmem_iov_offset,
 			     const void *src, size_t size);
 
+static inline int ofi_copy_to_hmem(enum fi_hmem_iface iface, uint64_t device,
+				   void *dest, const void *src, size_t size)
+{
+	return hmem_ops[iface].copy_to_hmem(device, dest, src, size);
+}
+
+static inline int ofi_copy_from_hmem(enum fi_hmem_iface iface, uint64_t device,
+				     void *dest, const void *src, size_t size)
+{
+	return hmem_ops[iface].copy_from_hmem(device, dest, src, size);
+}
+
 int ofi_hmem_get_handle(enum fi_hmem_iface iface, void *base_addr, void **handle);
 int ofi_hmem_open_handle(enum fi_hmem_iface iface, void **handle,
 			 uint64_t device, void **mapped_addr);

--- a/prov/efa/src/rxr/rxr_atomic.c
+++ b/prov/efa/src/rxr/rxr_atomic.c
@@ -137,9 +137,6 @@ ssize_t rxr_atomic_generic_efa(struct rxr_ep *rxr_ep,
 	assert(msg->iov_count <= rxr_ep->tx_iov_limit);
 	efa_perfset_start(rxr_ep, perf_efa_tx);
 
-	if (msg->desc && efa_mr_is_cuda(msg->desc[0]))
-		return -FI_ENOSYS;
-
 	ofi_mutex_lock(&rxr_ep->util_ep.lock);
 
 	if (OFI_UNLIKELY(is_tx_res_full(rxr_ep))) {
@@ -383,6 +380,8 @@ rxr_atomic_readwritemsg(struct fid_ep *ep,
 
 	ofi_ioc_to_iov(resultv, atomic_ex.resp_iov, result_count, datatype_size);
 	atomic_ex.resp_iov_count = result_count;
+	atomic_ex.result_desc = *result_desc;
+	atomic_ex.compare_desc = NULL;
 	return rxr_atomic_generic_efa(rxr_ep, msg, &atomic_ex, ofi_op_atomic_fetch, flags);
 }
 
@@ -475,6 +474,8 @@ rxr_atomic_compwritemsg(struct fid_ep *ep,
 
 	ofi_ioc_to_iov(comparev, atomic_ex.comp_iov, compare_count, datatype_size);
 	atomic_ex.comp_iov_count = compare_count;
+	atomic_ex.compare_desc = *compare_desc;
+	atomic_ex.result_desc = *result_desc;
 
 	return rxr_atomic_generic_efa(rxr_ep, msg, &atomic_ex, ofi_op_atomic_compare, flags);
 }

--- a/prov/efa/src/rxr/rxr_op_entry.h
+++ b/prov/efa/src/rxr/rxr_op_entry.h
@@ -80,6 +80,8 @@ struct rxr_atomic_ex {
 	int resp_iov_count;
 	struct iovec comp_iov[RXR_IOV_LIMIT];
 	int comp_iov_count;
+	void *result_desc;
+	void *compare_desc;
 };
 
 enum rxr_cuda_copy_method {
@@ -166,7 +168,7 @@ struct rxr_op_entry {
 	struct dlist_entry pending_recv_entry;
 #endif
 
-	size_t efa_outstanding_tx_ops; 
+	size_t efa_outstanding_tx_ops;
 	size_t shm_outstanding_tx_ops;
 
 	/*

--- a/prov/efa/src/rxr/rxr_pkt_type_misc.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_misc.c
@@ -209,10 +209,10 @@ ssize_t rxr_pkt_init_cts(struct rxr_ep *ep,
 		cts_hdr->flags |= RXR_CTS_READ_REQ;
 
 	/* CTS is sent by different communication protocols.
-	 * CTS is sent using tx_entry in the emulated longcts read 
-	 * protocol. The emulated longcts write and the longcts 
+	 * CTS is sent using tx_entry in the emulated longcts read
+	 * protocol. The emulated longcts write and the longcts
 	 * message protocols sends CTS using rx_entry.
-	 * This check ensures appropriate tx_id and rx_id are 
+	 * This check ensures appropriate tx_id and rx_id are
 	 * assigned for the respective protocols */
 	if (op_entry->type == RXR_TX_ENTRY){
 		cts_hdr->send_id = op_entry->rx_id;
@@ -419,8 +419,8 @@ void rxr_pkt_handle_rma_read_completion(struct rxr_ep *ep,
 			rxr_release_tx_entry(ep, tx_entry);
 		} else if (read_entry->context_type == RXR_READ_CONTEXT_RX_ENTRY) {
 			rx_entry = read_entry->context;
-			rxr_tracing(read_completed, 
-				    rx_entry->msg_id, (size_t) rx_entry->cq_entry.op_context, 
+			rxr_tracing(read_completed,
+				    rx_entry->msg_id, (size_t) rx_entry->cq_entry.op_context,
 				    rx_entry->total_len, (size_t) read_entry->context);
 			err = rxr_pkt_post_or_queue(ep, rx_entry, RXR_EOR_PKT, false);
 			if (OFI_UNLIKELY(err)) {
@@ -624,7 +624,7 @@ void rxr_pkt_handle_atomrsp_sent(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_en
 void rxr_pkt_handle_atomrsp_send_completion(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry)
 {
 	struct rxr_op_entry *rx_entry;
-	
+
 	rx_entry = (struct rxr_op_entry *)pkt_entry->x_entry;
 	ofi_buf_free(rx_entry->atomrsp_data);
 	rx_entry->atomrsp_data = NULL;

--- a/prov/efa/src/rxr/rxr_pkt_type_req.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_req.c
@@ -1190,7 +1190,7 @@ struct rxr_op_entry *rxr_pkt_get_msgrtm_rx_entry(struct rxr_ep *ep,
 
 	} else {
 		rx_entry = rxr_pkt_get_rtm_matched_rx_entry(ep, match, *pkt_entry_ptr);
-		rxr_tracing(msg_match_expected_nontagged, rx_entry->msg_id, 
+		rxr_tracing(msg_match_expected_nontagged, rx_entry->msg_id,
 			    (size_t) rx_entry->cq_entry.op_context, rx_entry->total_len);
 	}
 
@@ -1229,7 +1229,7 @@ struct rxr_op_entry *rxr_pkt_get_tagrtm_rx_entry(struct rxr_ep *ep,
 		}
 	} else {
 		rx_entry = rxr_pkt_get_rtm_matched_rx_entry(ep, match, *pkt_entry_ptr);
-		rxr_tracing(msg_match_expected_tagged, rx_entry->msg_id, 
+		rxr_tracing(msg_match_expected_tagged, rx_entry->msg_id,
 			    (size_t) rx_entry->cq_entry.op_context, rx_entry->total_len);
 	}
 
@@ -1256,7 +1256,7 @@ ssize_t rxr_pkt_proc_matched_longread_rtm(struct rxr_ep *ep,
 	       rx_entry->rma_iov_count * sizeof(struct fi_rma_iov));
 
 	rxr_pkt_entry_release_rx(ep, pkt_entry);
-	rxr_tracing(longread_read_posted, rx_entry->msg_id, 
+	rxr_tracing(longread_read_posted, rx_entry->msg_id,
 		    (size_t) rx_entry->cq_entry.op_context, rx_entry->total_len);
 	return rxr_read_post_remote_read_or_queue(ep, rx_entry);
 }
@@ -1285,7 +1285,7 @@ ssize_t rxr_pkt_proc_matched_mulreq_rtm(struct rxr_ep *ep,
 			read_iov = (struct fi_rma_iov *)((char *)pkt_entry->pkt + rxr_pkt_req_hdr_size_from_pkt_entry(pkt_entry));
 			rx_entry->rma_iov_count = runtread_rtm_hdr->read_iov_count;
 			memcpy(rx_entry->rma_iov, read_iov, rx_entry->rma_iov_count * sizeof(struct fi_rma_iov));
-			rxr_tracing(runtread_read_posted, rx_entry->msg_id, 
+			rxr_tracing(runtread_read_posted, rx_entry->msg_id,
 				    (size_t) rx_entry->cq_entry.op_context, rx_entry->total_len);
 			err = rxr_read_post_remote_read_or_queue(ep, rx_entry);
 			if (err)

--- a/prov/efa/src/rxr/rxr_pkt_type_req.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_req.c
@@ -2209,6 +2209,8 @@ ssize_t rxr_pkt_init_rta(struct rxr_ep *ep, struct rxr_op_entry *tx_entry,
 	struct rxr_rta_hdr *rta_hdr;
 	char *data;
 	size_t hdr_size, data_size;
+	uint64_t device;
+	enum fi_hmem_iface hmem_iface;
 	int i;
 
 	rta_hdr = (struct rxr_rta_hdr *)pkt_entry->pkt;
@@ -2227,8 +2229,14 @@ ssize_t rxr_pkt_init_rta(struct rxr_ep *ep, struct rxr_op_entry *tx_entry,
 
 	hdr_size = rxr_pkt_req_hdr_size_from_pkt_entry(pkt_entry);
 	data = (char *)pkt_entry->pkt + hdr_size;
-	data_size = ofi_copy_from_iov(data, ep->mtu_size - hdr_size,
-				      tx_entry->iov, tx_entry->iov_count, 0);
+	hmem_iface = ((struct efa_mr*) tx_entry->desc[0])->peer.iface;
+	device = ((struct efa_mr*) tx_entry->desc[0])->peer.device.reserved;
+
+	data_size = ofi_copy_from_hmem_iov(data, ep->mtu_size - hdr_size, hmem_iface, device,
+	                                   tx_entry->iov, tx_entry->iov_count, 0);
+
+	if (hmem_iface == FI_HMEM_CUDA)
+		cuda_flush_rdma_operations();
 
 	pkt_entry->pkt_size = hdr_size + data_size;
 	pkt_entry->x_entry = tx_entry;
@@ -2272,6 +2280,10 @@ ssize_t rxr_pkt_init_compare_rta(struct rxr_ep *ep, struct rxr_op_entry *tx_entr
 	char *data;
 	size_t data_size;
 	struct rxr_rta_hdr *rta_hdr;
+	uint64_t device;
+	enum fi_hmem_iface hmem_iface;
+
+	/* TODO Add check here to return early if buf size + compare_size > mtu_size - header_size */
 
 	rxr_pkt_init_rta(ep, tx_entry, RXR_COMPARE_RTA_PKT, pkt_entry);
 	rta_hdr = rxr_get_rta_hdr(pkt_entry->pkt);
@@ -2280,9 +2292,16 @@ ssize_t rxr_pkt_init_compare_rta(struct rxr_ep *ep, struct rxr_op_entry *tx_entr
 	 * the following append the data to be compared
 	 */
 	data = (char *)pkt_entry->pkt + pkt_entry->pkt_size;
-	data_size = ofi_copy_from_iov(data, ep->mtu_size - pkt_entry->pkt_size,
-				      tx_entry->atomic_ex.comp_iov,
-				      tx_entry->atomic_ex.comp_iov_count, 0);
+
+    hmem_iface = ((struct efa_mr*) tx_entry->atomic_ex.compare_desc)->peer.iface;
+    device = ((struct efa_mr*) tx_entry->atomic_ex.compare_desc)->peer.device.reserved;
+
+	data_size = ofi_copy_from_hmem_iov(data, ep->mtu_size - pkt_entry->pkt_size, hmem_iface, device,
+	                                   tx_entry->atomic_ex.comp_iov, tx_entry->atomic_ex.comp_iov_count, 0);
+
+	if (hmem_iface == FI_HMEM_CUDA)
+		cuda_flush_rdma_operations();
+
 	assert(data_size == tx_entry->total_len);
 	pkt_entry->pkt_size += data_size;
 	return 0;
@@ -2296,14 +2315,44 @@ void rxr_pkt_handle_write_rta_send_completion(struct rxr_ep *ep, struct rxr_pkt_
 	rxr_cq_handle_send_completion(ep, tx_entry);
 }
 
+static int rxr_cuda_write_atomic(struct efa_mr *efa_mr, struct iovec *iov, char* data, size_t dtsize, int op, int dt)
+{
+	char host_data[iov->iov_len];
+	uint64_t device = efa_mr->peer.device.reserved;
+	int ret;
+
+	/* Step 1: Copy data from device to temporary host buffer */
+	ret = ofi_copy_from_hmem(FI_HMEM_CUDA, device, host_data, iov->iov_base, iov->iov_len);
+	cuda_flush_rdma_operations();
+	if (OFI_UNLIKELY(!ret)) {
+		return ret;
+	}
+
+	/* Step 2: Perform atomic operation on host buffer */
+	ofi_atomic_write_handlers[op][dt](host_data,
+	                                  data,
+	                                  iov->iov_len / dtsize);
+
+	/* Step 3: Copy temporary host buffer to device */
+	ret = ofi_copy_to_hmem(FI_HMEM_CUDA, device, iov->iov_base, host_data, iov->iov_len);
+	cuda_flush_rdma_operations();
+	if (OFI_UNLIKELY(!ret)) {
+		return ret;
+	}
+
+	return 0;
+}
+
 int rxr_pkt_proc_write_rta(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry)
 {
 	struct iovec iov[RXR_IOV_LIMIT];
+	struct efa_mr *efa_mr;
 	struct rxr_rta_hdr *rta_hdr;
 	void *desc[RXR_IOV_LIMIT];
 	char *data;
-	int iov_count, op, dt, i;
+	int iov_count, op, dt, i, ret;
 	size_t dtsize, offset, hdr_size;
+	enum fi_hmem_iface hmem_iface;
 
 	rta_hdr = (struct rxr_rta_hdr *)pkt_entry->pkt;
 	op = rta_hdr->atomic_op;
@@ -2320,9 +2369,26 @@ int rxr_pkt_proc_write_rta(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry)
 
 	offset = 0;
 	for (i = 0; i < iov_count; ++i) {
-		ofi_atomic_write_handlers[op][dt](iov[i].iov_base,
-						  data + offset,
-						  iov[i].iov_len / dtsize);
+		/* Get hmem_iface from MR */
+		efa_mr = (struct efa_mr*) ofi_mr_map_get(&ep->util_ep.domain->mr_map, (rta_hdr->rma_iov + i)->key);
+		hmem_iface = efa_mr->peer.iface;
+
+		if (hmem_iface == FI_HMEM_SYSTEM) {
+			ofi_atomic_write_handlers[op][dt](iov[i].iov_base,
+			                                  data + offset,
+			                                  iov[i].iov_len / dtsize);
+		}
+		else if (hmem_iface == FI_HMEM_CUDA) {
+			ret = rxr_cuda_write_atomic(efa_mr, &iov[i], data + offset, dtsize, op, dt);
+			if (OFI_UNLIKELY(ret != 0)) {
+				return ret;
+			}
+		}
+		else {
+			FI_WARN(&rxr_prov, FI_LOG_CQ, "Atomics not supported for FI_HMEM_IFACE: %d.\n", hmem_iface);
+			return ENOSYS;
+		}
+
 		offset += iov[i].iov_len;
 	}
 
@@ -2417,13 +2483,44 @@ int rxr_pkt_proc_dc_write_rta(struct rxr_ep *ep,
 	return ret;
 }
 
+static int rxr_cuda_fetch_atomic(struct efa_mr *efa_mr, struct iovec *iov, char* data, void* result, size_t dtsize, int op, int dt)
+{
+	char host_data[iov->iov_len];
+	uint64_t device = efa_mr->peer.device.reserved;
+	int ret;
+
+	/* Step 1: Copy data from device to temporary host buffer */
+	ret = ofi_copy_from_hmem(FI_HMEM_CUDA, device, host_data, iov->iov_base, iov->iov_len);
+	cuda_flush_rdma_operations();
+	if (OFI_UNLIKELY(!ret)) {
+		return ret;
+	}
+
+	/* Step 2: Perform atomic operation on temporary host buffer */
+	ofi_atomic_readwrite_handlers[op][dt](host_data,
+	                                      data,
+	                                      result,
+	                                      iov->iov_len / dtsize);
+
+	/* Step 3: Copy data from host buffer to device */
+	ret = ofi_copy_to_hmem(FI_HMEM_CUDA, device, iov->iov_base, host_data, iov->iov_len);
+	cuda_flush_rdma_operations();
+	if (OFI_UNLIKELY(!ret)) {
+		return ret;
+	}
+
+	return 0;
+}
+
 int rxr_pkt_proc_fetch_rta(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry)
 {
 	struct rxr_op_entry *rx_entry;
+	struct efa_mr *efa_mr;
 	char *data;
-	int op, dt, i;
+	int op, dt, i, ret;
 	size_t offset, dtsize;
 	ssize_t err;
+	enum fi_hmem_iface hmem_iface;
 
 	rx_entry = rxr_pkt_alloc_rta_rx_entry(ep, pkt_entry, ofi_op_atomic_fetch);
 	if(OFI_UNLIKELY(!rx_entry)) {
@@ -2443,10 +2540,26 @@ int rxr_pkt_proc_fetch_rta(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry)
 
 	offset = 0;
 	for (i = 0; i < rx_entry->iov_count; ++i) {
-		ofi_atomic_readwrite_handlers[op][dt](rx_entry->iov[i].iov_base,
-						      data + offset,
-						      rx_entry->atomrsp_data + offset,
-						      rx_entry->iov[i].iov_len / dtsize);
+		efa_mr = (struct efa_mr*) ofi_mr_map_get(&ep->util_ep.domain->mr_map, (rxr_get_rta_hdr(pkt_entry->pkt)->rma_iov + i)->key);
+		hmem_iface = efa_mr->peer.iface;
+		if (hmem_iface == FI_HMEM_SYSTEM) {
+			ofi_atomic_readwrite_handlers[op][dt](rx_entry->iov[i].iov_base,
+			                                      data + offset,
+			                                      rx_entry->atomrsp_data + offset,
+			                                      rx_entry->iov[i].iov_len / dtsize);
+		}
+		else if (hmem_iface == FI_HMEM_CUDA) {
+			ret = rxr_cuda_fetch_atomic(efa_mr, &rx_entry->iov[i], data + offset,
+			                            rx_entry->atomrsp_data + offset, dtsize, op, dt);
+			if (OFI_UNLIKELY(ret != 0)) {
+				return ret;
+			}
+		}
+		else {
+			FI_WARN(&rxr_prov, FI_LOG_CQ, "Atomics not supported for FI_HMEM_IFACE: %d.\n", hmem_iface);
+			return ENOSYS;
+		}
+
 		offset += rx_entry->iov[i].iov_len;
 	}
 
@@ -2458,11 +2571,39 @@ int rxr_pkt_proc_fetch_rta(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry)
 	return 0;
 }
 
+static int rxr_cuda_compare_atomic(struct efa_mr *efa_mr, struct iovec *dst, char* src, void* res, void* cmp, size_t dtsize, int op, int dt)
+{
+	char host_data[dst->iov_len];
+	uint64_t device = efa_mr->peer.device.reserved;
+	int ret;
+
+	/* Step 1: Copy From HMEM into temp_host_buffer */
+	ret = ofi_copy_from_hmem(FI_HMEM_CUDA, device, host_data, dst->iov_base, dst->iov_len);
+	cuda_flush_rdma_operations();
+	if (OFI_UNLIKELY(!ret)) {
+		return ret;
+	}
+
+	/* Step 2: Perform the atomic operation on host buffer */
+	ofi_atomic_swap_handler(op, dt, dst->iov_base, src, cmp, res, dst->iov_len / dtsize);
+
+	/* Step 3: Copy host buffer back to device*/
+	ret = ofi_copy_to_hmem(FI_HMEM_CUDA, device, dst->iov_base, host_data, dst->iov_len);
+	cuda_flush_rdma_operations();
+	if (OFI_UNLIKELY(!ret)) {
+		return ret;
+	}
+
+	return 0;
+}
+
 int rxr_pkt_proc_compare_rta(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry)
 {
+	struct efa_mr *efa_mr;
 	struct rxr_op_entry *rx_entry;
 	char *src_data, *cmp_data;
-	int op, dt, i;
+	int op, dt, i, ret;
+	enum fi_hmem_iface hmem_iface;
 	size_t offset, dtsize;
 	ssize_t err;
 
@@ -2498,37 +2639,71 @@ int rxr_pkt_proc_compare_rta(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry)
 	 */
 	if (dt == FI_INT128) {
 		for (i = 0; i < rx_entry->iov_count; ++i) {
-			ofi_int128_t src, cmp;
-			memcpy(&src, src_data + offset, sizeof(ofi_int128_t));
-			memcpy(&cmp, cmp_data + offset, sizeof(ofi_int128_t));
+			efa_mr = (struct efa_mr*) ofi_mr_map_get(&ep->util_ep.domain->mr_map, (rxr_get_rta_hdr(pkt_entry->pkt)->rma_iov + i)->key);
+			hmem_iface = efa_mr->peer.iface;
 
-			ofi_atomic_swap_handler(op, dt, rx_entry->iov[i].iov_base,
-									&src,
-									&cmp,
-									rx_entry->atomrsp_data + offset,
-									rx_entry->iov[i].iov_len / dtsize);
-			offset += rx_entry->iov[i].iov_len;
+			if (hmem_iface == FI_HMEM_SYSTEM) {
+				ofi_int128_t src, cmp;
+				memcpy(&src, src_data + offset, sizeof(ofi_int128_t));
+				memcpy(&cmp, cmp_data + offset, sizeof(ofi_int128_t));
+
+				ofi_atomic_swap_handler(op, dt, rx_entry->iov[i].iov_base,
+				                        &src,
+				                        &cmp,
+				                        rx_entry->atomrsp_data + offset,
+				                        rx_entry->iov[i].iov_len / dtsize);
+				offset += rx_entry->iov[i].iov_len;
+			} else {
+				FI_WARN(&rxr_prov, FI_LOG_CQ, "Atomics not supported for FI_HMEM_IFACE: %d.\n", hmem_iface);
+				return ENOSYS;
+			}
 		}
 	} else if (dt == FI_UINT128) {
 		for (i = 0; i < rx_entry->iov_count; ++i) {
-			ofi_uint128_t src, cmp;
-			memcpy(&src, src_data + offset, sizeof(ofi_uint128_t));
-			memcpy(&cmp, cmp_data + offset, sizeof(ofi_uint128_t));
-			ofi_atomic_swap_handler(op, dt, rx_entry->iov[i].iov_base,
-									&src,
-									&cmp,
-									rx_entry->atomrsp_data + offset,
-									rx_entry->iov[i].iov_len / dtsize);
-			offset += rx_entry->iov[i].iov_len;
+			efa_mr = (struct efa_mr*) ofi_mr_map_get(&ep->util_ep.domain->mr_map, (rxr_get_rta_hdr(pkt_entry->pkt)->rma_iov + i)->key);
+			hmem_iface = efa_mr->peer.iface;
+
+			if (hmem_iface == FI_HMEM_SYSTEM) {
+				ofi_uint128_t src, cmp;
+				memcpy(&src, src_data + offset, sizeof(ofi_uint128_t));
+				memcpy(&cmp, cmp_data + offset, sizeof(ofi_uint128_t));
+
+				ofi_atomic_swap_handler(op, dt, rx_entry->iov[i].iov_base,
+				                        &src,
+				                        &cmp,
+				                        rx_entry->atomrsp_data + offset,
+			                            rx_entry->iov[i].iov_len / dtsize);
+				offset += rx_entry->iov[i].iov_len;
+			} else {
+				FI_WARN(&rxr_prov, FI_LOG_CQ, "Atomics not supported for FI_HMEM_IFACE: %d.\n", hmem_iface);
+				return ENOSYS;
+			}
 		}
 	} else {
 #endif
 		for (i = 0; i < rx_entry->iov_count; ++i) {
-			ofi_atomic_swap_handler(op, dt, rx_entry->iov[i].iov_base,
-									src_data + offset,
-									cmp_data + offset,
-									rx_entry->atomrsp_data + offset,
-									rx_entry->iov[i].iov_len / dtsize);
+			efa_mr = (struct efa_mr*) ofi_mr_map_get(&ep->util_ep.domain->mr_map, (rxr_get_rta_hdr(pkt_entry->pkt)->rma_iov + i)->key);
+			hmem_iface = efa_mr->peer.iface;
+
+			if (hmem_iface == FI_HMEM_SYSTEM) {
+				ofi_atomic_swap_handler(op, dt, rx_entry->iov[i].iov_base,
+				                        src_data + offset,
+				                        cmp_data + offset,
+				                        rx_entry->atomrsp_data + offset,
+				                        rx_entry->iov[i].iov_len / dtsize);
+			}
+			else if (hmem_iface == FI_HMEM_CUDA) {
+				ret = rxr_cuda_compare_atomic(efa_mr, &rx_entry->iov[i], src_data + offset,
+				                              rx_entry->atomrsp_data + offset, cmp_data + offset,
+				                              dtsize, op, dt);
+				if (OFI_UNLIKELY(ret != 0)) {
+					return ret;
+				}
+			}
+			else {
+				FI_WARN(&rxr_prov, FI_LOG_CQ, "Atomics not supported for FI_HMEM_IFACE: %d.\n", hmem_iface);
+				return ENOSYS;
+			}
 			offset += rx_entry->iov[i].iov_len;
 		}
 #ifdef HAVE___INT128

--- a/src/hmem.c
+++ b/src/hmem.c
@@ -131,18 +131,6 @@ struct ofi_hmem_ops hmem_ops[] = {
 	},
 };
 
-static inline int ofi_copy_to_hmem(enum fi_hmem_iface iface, uint64_t device,
-				   void *dest, const void *src, size_t size)
-{
-	return hmem_ops[iface].copy_to_hmem(device, dest, src, size);
-}
-
-static inline int ofi_copy_from_hmem(enum fi_hmem_iface iface, uint64_t device,
-				     void *dest, const void *src, size_t size)
-{
-	return hmem_ops[iface].copy_from_hmem(device, dest, src, size);
-}
-
 static ssize_t ofi_copy_hmem_iov_buf(enum fi_hmem_iface hmem_iface, uint64_t device,
 				     const struct iovec *hmem_iov,
 				     size_t hmem_iov_count,

--- a/src/hmem_cuda.c
+++ b/src/hmem_cuda.c
@@ -56,7 +56,7 @@ struct cuda_ops {
 	CUresult (*cuPointerGetAttribute)(void *data,
 					  CUpointer_attribute attribute,
 					  CUdeviceptr ptr);
-	CUresult (*cuPointerSetAttribute)(void *data,
+	CUresult (*cuPointerSetAttribute)(const void *data,
 					  CUpointer_attribute attribute,
 					  CUdeviceptr ptr);
 	CUresult (*cuMemGetAddressRange)( CUdeviceptr* pbase,


### PR DESCRIPTION
Changes to prov/efa to add emulated atomic support for CUDA devices:

1. Added result + fetch memory descriptors to rxr_atomic_ex
2. Switched every memcpy to be ofi_hmem memcpy
3. On the target side, added ofi_hmem memcpy's around emulated atomic impl functions, and performed them on host memory.

Testing:
```
fi_rdm_atomic -D cuda -p efa -E  # passes, and exits cleanly
fi_rdm_atomic -p efa -E                # passes, and exits cleanly
```

Tested both sides no cuda, both sides cuda, and one side cuda, one side host.  There is a big slow down when using atomics with CUDA devices (which is expected).